### PR TITLE
change to woceatlas.ucsd.edu

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,9 +84,10 @@
     <div class="row text-center">
       <div class="col-sm-6">
         <div class="well">
-          <a href="http://antarctica.tamu.edu/woceatlas/html/index.html">
+          <!--<a href="http://antarctica.tamu.edu/woceatlas/html/index.html">
             <img class="img-responsive" src="img/southern.png" title="Go to Southern Atlas">
-          </a>
+          </a> -->
+          Southern Ocean Atlas is <br> temporarily unavailable
         </a>
       </div> 
     </div><!-- /.col-md-3 -->


### PR DESCRIPTION
removed broken link to Southern ocean atlas,   added text that southern ocean atlas is temporarily unavailable.